### PR TITLE
Success, error and cancel URLs with query parameters

### DIFF
--- a/SBRXCallbackURLKit/NSURL+SBRXCallbackURL.m
+++ b/SBRXCallbackURLKit/NSURL+SBRXCallbackURL.m
@@ -18,7 +18,7 @@
   [chunks enumerateObjectsUsingBlock:^(id obj, NSUInteger idx, BOOL *stop) {
     NSArray *parts = [obj componentsSeparatedByString:@"="];
     
-    if ([parts count] == 2) {
+    if ([parts count] >= 2) {
       NSString *name = parts[0];
       NSString *value = parts[1];
       parameters[name] = [value sbr_URLDecode];

--- a/SBRXCallbackURLKitTests/SBRXCallbackURLKitTests.m
+++ b/SBRXCallbackURLKitTests/SBRXCallbackURLKitTests.m
@@ -9,6 +9,7 @@
 #import "SBRCallbackAction.h"
 #import "SBRCallbackParser.h"
 #import "SBRCallbackParserMockDelegate.h"
+#import "NSURL+SBRXCallbackURL.h"
 
 static NSString * const kURLScheme = @"demoapp";
 
@@ -219,6 +220,14 @@ static NSString * const kURLScheme = @"demoapp";
   
   STAssertTrue(called == shouldBeCalled, (shouldBeCalled ? @"Handler block was not called." : @"Handler block was called when it shouldn't."));
   STAssertTrue(handled == shouldBeCalled, (shouldBeCalled ? @"URL was not handled." : @"URL was handled when it shouldn't."));
+}
+
+#pragma mark - NSURL+SBRXCallbackURL
+
+- (void)test_sbr_queryParameters_url_params {
+    NSURL *testURL = [NSURL URLWithString:@"linkly://x-callback-url/clipURL?url=123&x-source=Safari&x-success=http://wiki.akosma.com&x-error=http://google.com?q=Test"];
+    NSDictionary *queryParams = [testURL sbr_queryParameters];
+    STAssertTrue([queryParams count] == 4, @"Expected 4 query params");
 }
 
 @end


### PR DESCRIPTION
This enables you to provide an URL like `x-error=http://google.com?q=test`
