### PR TITLE
Adds an explicit cast to unsigned long

### DIFF
--- a/SBRXCallbackURLKit/SBRCallbackParser.m
+++ b/SBRXCallbackURLKit/SBRCallbackParser.m
@@ -235,7 +235,7 @@
   NSString *callback = xParameters[@"x-error"];
   
   if ([callback length] > 0) {
-    NSDictionary *parameters = @{@"errorCode": [NSString stringWithFormat:@"%d", code],
+    NSDictionary *parameters = @{@"errorCode": [NSString stringWithFormat:@"%lu", code],
                                  @"errorMessage": message};
     [self callSourceCallbackURLString:callback parameters:parameters];
   }


### PR DESCRIPTION
Removes the warning related to format arguments
