### PR TITLE
Fix error code

### DIFF
--- a/SBRXCallbackURLKit/SBRCallbackAction.m
+++ b/SBRXCallbackURLKit/SBRCallbackAction.m
@@ -92,7 +92,7 @@
     NSString *errorAction = [NSString stringWithFormat:@"%@-%@-error", self.URLScheme, self.name];
     
     SBRCallbackActionHandler *handler = [parser addHandlerForActionName:errorAction handlerBlock:^BOOL(NSDictionary *parameters, NSString *source, SBRCallbackActionHandlerCompletionBlock completion) {
-      NSUInteger code = [parameters[@"errorCode"] integerValue];
+      NSInteger code = [parameters[@"errorCode"] integerValue];
       NSString *message = parameters[@"errorMessage"];
       NSError *error = [NSError sbr_errorWithCode:code message:message];
       

--- a/SBRXCallbackURLKit/SBRCallbackParser.h
+++ b/SBRXCallbackURLKit/SBRCallbackParser.h
@@ -8,7 +8,7 @@
 #import <Foundation/Foundation.h>
 #import "SBRCallbackActionHandler.h"
 
-typedef NS_ENUM(NSUInteger, SBRCallbackParserError) {
+typedef NS_ENUM(NSInteger, SBRCallbackParserError) {
   SBRCallbackParserErrorMissingParameter = 1,
 };
 

--- a/SBRXCallbackURLKit/SBRCallbackParser.m
+++ b/SBRXCallbackURLKit/SBRCallbackParser.m
@@ -226,7 +226,7 @@
   [self callErrorCallbackInXParameters:xParameters code:error.code message:[error localizedDescription]];
 }
 
-- (void)callErrorCallbackInXParameters:(NSDictionary *)xParameters code:(NSUInteger)code message:(NSString *)message {
+- (void)callErrorCallbackInXParameters:(NSDictionary *)xParameters code:(NSInteger)code message:(NSString *)message {
   // x-error:
   // URL to open if the requested action generates an error in the target app. This URL
   // will be open with at least the parameters “errorCode=code&errorMessage=message. If x-error

--- a/SBRXCallbackURLKit/SBRCallbackParser.m
+++ b/SBRXCallbackURLKit/SBRCallbackParser.m
@@ -235,7 +235,7 @@
   NSString *callback = xParameters[@"x-error"];
   
   if ([callback length] > 0) {
-    NSDictionary *parameters = @{@"errorCode": [NSString stringWithFormat:@"%lu", code],
+    NSDictionary *parameters = @{@"errorCode": [NSString stringWithFormat:@"%ld", (long)code],
                                  @"errorMessage": message};
     [self callSourceCallbackURLString:callback parameters:parameters];
   }


### PR DESCRIPTION
##### Type of instance

Type of `code` property of `NSError` is `NSInteger`.

``` objc
@property(readonly) NSInteger code
```

So I changed type `NSUInteger` to `NSInteger`.
##### 64bit support

String format for `NSInteger`and `NSUInteger` needs cast for fixing warning.

Reference is in the following.
https://developer.apple.com/library/ios/documentation/Cocoa/Conceptual/Strings/Articles/formatSpecifiers.html#//apple_ref/doc/uid/TP40004265-SW5
