### PR TITLE
Got rid of a compiler warning when compiling for 64-bit arch.

### DIFF
--- a/SBRXCallbackURLKit/SBRCallbackParser.m
+++ b/SBRXCallbackURLKit/SBRCallbackParser.m
@@ -235,7 +235,7 @@
   NSString *callback = xParameters[@"x-error"];
   
   if ([callback length] > 0) {
-    NSDictionary *parameters = @{@"errorCode": [NSString stringWithFormat:@"%lu", code],
+    NSDictionary *parameters = @{@"errorCode": [NSString stringWithFormat:@"%lu", (unsigned long)code],
                                  @"errorMessage": message};
     [self callSourceCallbackURLString:callback parameters:parameters];
   }


### PR DESCRIPTION
Hey! Just wanted to fix a little warning which appears when building it for ARM 64.
