### PR TITLE
Add support for returning parameters in case of error, this will allo…

### DIFF
--- a/SBRXCallbackURLKit/SBRCallbackParser.h
+++ b/SBRXCallbackURLKit/SBRCallbackParser.h
@@ -40,5 +40,5 @@ typedef NS_ENUM(NSUInteger, SBRCallbackParserError) {
 @optional
 
 - (void)xCallbackURLParser:(SBRCallbackParser *)parser shouldOpenSourceCallbackURL:(NSURL *)callbackURL;
-
+- (void)xCallbackURLParser:(SBRCallbackParser *)parser missingRequiredParameters:(NSArray *) missingParameters inURL:(NSURL *)URL;
 @end

--- a/SBRXCallbackURLKit/SBRCallbackParser.m
+++ b/SBRXCallbackURLKit/SBRCallbackParser.m
@@ -130,7 +130,12 @@
   NSArray *missingParameters = [self missingParametersInUserParameters:userParameters requiredParameters:handler.requiredParameters];
   if ([missingParameters count] > 0) {
     NSString *message = [NSString stringWithFormat:@"Missing parameters %@", [missingParameters componentsJoinedByString:@"m"]];
-    [self callErrorCallbackInXParameters:xParameters code:SBRCallbackParserErrorMissingParameter message:message];
+    if ([self.delegate respondsToSelector:@selector(xCallbackURLParser:missingRequiredParameters:inURL:)]) {
+      [self.delegate xCallbackURLParser:self missingRequiredParameters:missingParameters inURL:URL];
+      [self callErrorCallbackInXParameters:xParameters code:SBRCallbackParserErrorMissingParameter message:message];
+    }else{
+      [self callErrorCallbackInXParameters:xParameters code:SBRCallbackParserErrorMissingParameter message:message];
+    }
     return NO;
   }
   

--- a/SBRXCallbackURLKit/SBRCallbackParser.m
+++ b/SBRXCallbackURLKit/SBRCallbackParser.m
@@ -214,7 +214,13 @@
 
 - (void)performCallbacksInXParameters:(NSDictionary *)xParameters successParameters:(NSDictionary *)successParameters error:(NSError *)error cancelled:(BOOL)cancelled {
   if (error) {
-    [self callErrorCallbackInXParameters:xParameters error:error];
+    //Oggerschummer begin
+    if (!successParameters){
+      [self callErrorCallbackInXParameters:xParameters error:error];
+    }else{
+      [self callErrorCallbackInXParameters:xParameters successParameters:successParameters];
+    }
+    //Oggerschummer end
   } else if (cancelled) {
     [self callCancelledCallbackInXParameters:xParameters];
   } else {
@@ -235,9 +241,23 @@
   NSString *callback = xParameters[@"x-error"];
   
   if ([callback length] > 0) {
-    NSDictionary *parameters = @{@"errorCode": [NSString stringWithFormat:@"%lu", code],
+    NSDictionary *parameters = @{@"errorCode": [NSString stringWithFormat:@"%d", code],
                                  @"errorMessage": message};
     [self callSourceCallbackURLString:callback parameters:parameters];
+  }
+}
+- (void)callErrorCallbackInXParameters:(NSDictionary *)xParameters successParameters:(NSDictionary *)successParameters {
+    // x-error:
+    // If the action in the target method is intended to return a result to the source
+    // app, the x-callback parameter should be included and provide a URL to open to return to
+    // the source app. On completion of the action, the target app will open this URL, possibly
+    // with additional parameters tacked on to return a result to the source app. If x-success
+    // is not provided, it is assumed that the user will stay in the target app on successful
+    // completion of the action.
+  NSString *callback = xParameters[@"x-error"];
+
+  if ([callback length] > 0) {
+    [self callSourceCallbackURLString:callback parameters:successParameters];
   }
 }
 


### PR DESCRIPTION
Allow the calling app to e.g. identify which initial call went wrong by checking the return parameters.

Specification says that at least the error code and the description will be returned, but it does not limit the parameters to those two. 
This change allows to transfer user parameters (error code and description overrule user parameters) in case of an x-error callback.
The same should be true to the x-cancel action (which is not adjusted here yet, but would work out similar).
In case no user parameters are provided the behavior will be exactly the same as before.

20180129
Added delegate method to allow the application to react on missing required parameters e.g. show a message to the user before returning to the source application with an error.